### PR TITLE
Update FileExplorer action button visibility logic

### DIFF
--- a/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/FileExplorer.js
@@ -77,11 +77,16 @@ class FileExplorer extends Panel
     }
   }
 
+  isActionEnabled(name)
+  {   
+    return true; 
+  }
+
   addContextButton(name, label, action, isVisible)
   {
     const buttonElem = Controls.addButton(this.buttonsPanelElem,
       name, label, action);
-    buttonElem._isVisible = isVisible;
+    buttonElem._isVisible = () => this.isActionEnabled(name) && isVisible();
   }
 
   addContextButtons()


### PR DESCRIPTION
Replaced the static boolean assignment to buttonElem._isVisible with a dynamic function that returns this.isActionEnabled(name) && isVisible(). This ensures that action buttons are only visible when the corresponding action is enabled and the previous visibility logic still passes.