### PR TITLE
Added manual parsing for Mongo

### DIFF
--- a/bimrocket-server/src/main/java/org/bimrocket/dao/mongo/MongoClientManager.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/dao/mongo/MongoClientManager.java
@@ -94,7 +94,7 @@ public class MongoClientManager
           .build());
 
       CodecRegistry codecRegistry = fromRegistries(
-        MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry, fromCodecs(new ObjectCodec()));
+        MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry, fromCodecs(new ObjectCodec(pojoCodecRegistry)));
 
       MongoClientSettings clientSettings = MongoClientSettings.builder()
         .applyConnectionString(connectionString)


### PR DESCRIPTION
The TaskData class has a property data of type Object. OrientDB allows automatic parsing to its database, but Mongo does not accept Object. Therefore: 
- ObjectCodec was created (In the document to be written, it maps the received Objects to a format recognizable by Mongo (Map, String, ...))
- The MongoClientManager class, in the getDefaultCodecRegistry method, includes this new ObjectCodec class as a parameter:
`MongoClientSettings.getDefaultCodecRegistry(), pojoCodecRegistry, fromCodecs(new ObjectCodec()));`