### PR TITLE
47-Improve error handling when loading a model 

### DIFF
--- a/bimrocket-webapp/src/main/webapp/js/ui/Application.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/Application.js
@@ -2050,17 +2050,33 @@ class Application
         application.initTasks();
       },
       onError : error =>
-        {
+      {
         application.progressBar.visible = false;
-  
-        if (error.includes("404"))
+
+        const stringifiedError = String(error);
+
+        if (stringifiedError.includes("404"))
         {
-          return MessageDialog.create("ERROR", "Model not found").setClassName("error").setI18N(this.i18n).show();
+          return MessageDialog
+            .create("ERROR", "Model not found")
+            .setClassName("error")
+            .setI18N(this.i18n)
+            .show();
         }
-  
+        else if (stringifiedError.includes("401") || stringifiedError.includes("403"))
+        {
           dialog.show();
-        },
-      options : { units : application.setup.units }
+        }
+        else
+        {
+          return MessageDialog
+            .create("ERROR", stringifiedError)
+            .setClassName("error")
+            .setI18N(this.i18n)
+            .show();
+        }
+      },
+      options : { units : application.setup.units },
     };
 
     dialog.login = (username, password) =>


### PR DESCRIPTION
- 404 → Modal with the text: "Model not found"
- 401 or 403 → The modal to enter credentials appears again
- Any other HTTP code → Displays the error as a red string