### PR TITLE
Add drag & drop functionality to open IFC files

### DIFF
--- a/bimrocket-webapp/src/main/webapp/css/tools.css
+++ b/bimrocket-webapp/src/main/webapp/css/tools.css
@@ -3,6 +3,98 @@
     Author     : realor
 */
 
+/* Drag & Drop */
+
+.drop_overlay
+{
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+  transition: background-color 0.2s ease;
+}
+
+.drop_overlay.outside
+{
+  background-color: rgba(200, 0, 0, 0.3);
+  cursor: not-allowed;
+}
+
+.drop_overlay.inside
+{
+  background-color: rgba(0, 0, 0, 0.7);
+  cursor: copy;
+}
+
+.drop_overlay > .drop_message
+{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.drop_overlay.outside > .drop_message > .drop_icon
+{
+  width: 80px;
+  height: 80px;
+  border: 4px dashed #ff6666;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 100, 100, 0.2);
+}
+
+.drop_overlay.inside > .drop_message > .drop_icon
+{
+  width: 80px;
+  height: 80px;
+  border: 4px dashed #66ff66;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(100, 255, 100, 0.2);
+}
+
+.drop_overlay > .drop_message > .drop_icon::before
+{
+  content: "+";
+  font-size: 48px;
+  font-weight: bold;
+  color: white;
+}
+
+.drop_overlay.outside > .drop_message > .drop_icon::before
+{
+  content: "✕";
+  color: #ff6666;
+}
+
+.drop_overlay.inside > .drop_message > .drop_icon::before
+{
+  content: "+";
+  color: #66ff66;
+}
+
+.drop_overlay > .drop_message > .drop_text
+{
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
 .service_panel
 {
   display: flex;

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -684,5 +684,8 @@ export const translations =
   "controller.KnobController" : "Shows a knob.",
   "controller.TranslationController" : "Translates an object.",
   "controller.ScriptController" : "Executes a program in JavaScript language.",
-  "controller.RestPollController" : "Polls a REST service."
+  "controller.RestPollController" : "Polls a REST service.",
+
+  "drop.text" : "Drop IFC file here",
+  "drop.error.invalid_files" : "Invalid file format. Only IFC files are supported."
 };

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -684,5 +684,8 @@ export const translations =
   "controller.KnobController" : "Mostra una perilla.",
   "controller.TranslationController" : "Desplaça un objecte.",
   "controller.ScriptController" : "Executa un programa en llenguatge JavaScript.",
-  "controller.RestPollController" : "Crida un servei REST periòdicament."
+  "controller.RestPollController" : "Crida un servei REST periòdicament.",
+
+  "drop.text" : "Arrossegueu un fitxer IFC aquí",
+  "drop.error.invalid_files" : "Format de fitxer no vàlid. Només s'admeten fitxers IFC."
 };

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -684,5 +684,8 @@ export const translations =
   "controller.KnobController" : "Muestra una perilla.",
   "controller.TranslationController" : "Desplaza un objeto.",
   "controller.ScriptController" : "Ejecuta un programa en lenguaje JavaScript.",
-  "controller.RestPollController" : "Llama un servicio REST periódicamente."
+  "controller.RestPollController" : "Llama un servicio REST periódicamente.",
+
+  "drop.text" : "Arrastra un archivo IFC aquí",
+  "drop.error.invalid_files" : "Formato de archivo no válido. Solo se admiten archivos IFC."
 };

--- a/bimrocket-webapp/src/main/webapp/js/ui/Application.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/Application.js
@@ -39,6 +39,7 @@ import { ObjectBatcher } from "../utils/ObjectBatcher.js";
 import { I18N } from "../i18n/I18N.js";
 import WebGL from "../utils/WebGL.js";
 import { Environment } from "../Environment.js";
+import { DragDropHandler } from "./DragDropHandler.js";
 import * as THREE from "three";
 
 class Application
@@ -425,6 +426,9 @@ class Application
     };
 
     animate();
+
+    this.dragDropHandler = new DragDropHandler(this);
+
     this.loadModules();
   }
 

--- a/bimrocket-webapp/src/main/webapp/js/ui/DragDropHandler.js
+++ b/bimrocket-webapp/src/main/webapp/js/ui/DragDropHandler.js
@@ -1,0 +1,323 @@
+/*
+ * DragDropHandler.js
+ *
+ */
+
+import { IOManager } from "../io/IOManager.js";
+import { ObjectUtils } from "../utils/ObjectUtils.js";
+import { MessageDialog } from "../ui/MessageDialog.js";
+
+class DragDropHandler
+{
+  constructor(application)
+  {
+    this.application = application;
+    this.container = application.container;
+    this.enabled = true;
+    this.dropOverlay = null;
+    this.isInsideValidArea = false;
+
+    this.fileQueue = [];
+    this.isProcessingQueue = false;
+
+    this._onDragOver = this.onDragOver.bind(this);
+    this._onDragLeave = this.onDragLeave.bind(this);
+    this._onDrop = this.onDrop.bind(this);
+
+    this.addEventListeners();
+  }
+
+  addEventListeners()
+  {
+    this.container.addEventListener("dragover", this._onDragOver, false);
+    this.container.addEventListener("dragleave", this._onDragLeave, false);
+    this.container.addEventListener("drop", this._onDrop, false);
+  }
+
+  removeEventListeners()
+  {
+    this.container.removeEventListener("dragover", this._onDragOver, false);
+    this.container.removeEventListener("dragleave", this._onDragLeave, false);
+    this.container.removeEventListener("drop", this._onDrop, false);
+  }
+
+  onDragOver(event)
+  {
+    if (!this.enabled) return;
+
+    event.preventDefault();
+
+    const canHandle = this.shouldHandleEvent(event);
+    const wasInside = this.isInsideValidArea;
+    this.isInsideValidArea = canHandle;
+
+    if (canHandle)
+    {
+      event.dataTransfer.dropEffect = "copy";
+    }
+    else
+    {
+      event.dataTransfer.dropEffect = "none";
+    }
+
+    if (!this.dropOverlay)
+    {
+      this.showDropOverlay();
+    }
+
+    if (wasInside !== canHandle)
+    {
+      this.updateDropOverlayState();
+    }
+  }
+
+  onDragLeave(event)
+  {
+    if (!this.enabled) return;
+
+    event.preventDefault();
+
+    const rect = this.container.getBoundingClientRect();
+    const x = event.clientX;
+    const y = event.clientY;
+
+    if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom)
+    {
+      this.isInsideValidArea = false;
+      this.hideDropOverlay();
+    }
+  }
+
+  onDrop(event)
+  {
+    if (!this.enabled) return;
+
+    event.preventDefault();
+    this.hideDropOverlay();
+
+    const files = event.dataTransfer.files;
+    if (files.length === 0) return;
+
+    if (this.shouldHandleEvent(event))
+    {
+      this.enqueueFiles(files);
+    }
+  }
+
+  shouldHandleEvent(event)
+  {
+    let elem = event.target;
+    while (elem && elem !== this.container)
+    {
+      if (elem.classList.contains("panel") ||
+          elem.classList.contains("resizer") ||
+          elem.classList.contains("service_panel") ||
+          elem.classList.contains("toolbar") ||
+          elem.tagName === "HEADER")
+      {
+        return false;
+      }
+      elem = elem.parentElement;
+    }
+    return elem === this.container;
+  }
+
+  updateDropOverlayState()
+  {
+    if (this.dropOverlay)
+    {
+      if (this.isInsideValidArea)
+      {
+        this.dropOverlay.classList.remove("outside");
+        this.dropOverlay.classList.add("inside");
+      }
+      else
+      {
+        this.dropOverlay.classList.remove("inside");
+        this.dropOverlay.classList.add("outside");
+      }
+    }
+  }
+
+  showDropOverlay()
+  {
+    const overlay = document.createElement("div");
+    overlay.className = "drop_overlay " + (this.isInsideValidArea ? "inside" : "outside");
+
+    const messageDiv = document.createElement("div");
+    messageDiv.className = "drop_message";
+
+    const iconDiv = document.createElement("div");
+    iconDiv.className = "drop_icon";
+
+    const textDiv = document.createElement("div");
+    textDiv.className = "drop_text";
+    textDiv.textContent = this.application.i18n.get("drop.text");
+
+    messageDiv.appendChild(iconDiv);
+    messageDiv.appendChild(textDiv);
+    overlay.appendChild(messageDiv);
+
+    this.container.appendChild(overlay);
+    this.dropOverlay = overlay;
+  }
+
+  hideDropOverlay()
+  {
+    if (this.dropOverlay)
+    {
+      this.dropOverlay.remove();
+      this.dropOverlay = null;
+    }
+  }
+
+  enqueueFiles(files)
+  {
+    const validFiles = this.validateFiles(files);
+    if (validFiles.length === 0)
+    {
+      MessageDialog.create("ERROR", "drop.error.invalid_files")
+        .setClassName("error")
+        .setI18N(this.application.i18n)
+        .show();
+      return;
+    }
+
+    for (let i = 0; i < validFiles.length; i++)
+    {
+      this.fileQueue.push(validFiles[i]);
+    }
+
+    if (!this.isProcessingQueue)
+    {
+      this.processQueue();
+    }
+  }
+
+  async processQueue()
+  {
+    if (this.fileQueue.length === 0)
+    {
+      this.isProcessingQueue = false;
+      return;
+    }
+
+    this.isProcessingQueue = true;
+
+    while (this.fileQueue.length > 0)
+    {
+      const file = this.fileQueue.shift();
+      await this.loadFile(file);
+    }
+
+    this.isProcessingQueue = false;
+  }
+
+  validateFiles(files)
+  {
+    const validFiles = [];
+    const supportedExtensions = IOManager.getSupportedLoaderExtensions();
+
+    for (let i = 0; i < files.length; i++)
+    {
+      const file = files[i];
+      const extension = this.getFileExtension(file.name);
+      if (supportedExtensions.includes(extension))
+      {
+        validFiles.push(file);
+      }
+    }
+    return validFiles;
+  }
+
+  getFileExtension(fileName)
+  {
+    const index = fileName.lastIndexOf(".");
+    if (index !== -1)
+    {
+      return fileName.substring(index + 1).toLowerCase();
+    }
+    return "";
+  }
+
+  loadFile(file)
+  {
+    return new Promise((resolve, reject) =>
+    {
+      const application = this.application;
+      const reader = new FileReader();
+
+      reader.onload = evt =>
+      {
+        const data = evt.target.result;
+        const intent =
+        {
+          url: "file://" + file.name,
+          data: data,
+          onProgress: data =>
+          {
+            application.progressBar.progress = data.progress;
+            application.progressBar.message = data.message;
+          },
+          onCompleted: object =>
+          {
+            const container = application.container;
+            const baseObject = application.baseObject;
+            const aspect = container.clientWidth / container.clientHeight;
+            const camera = application.camera;
+
+            object.updateMatrix();
+            application.addObject(object, baseObject);
+
+            ObjectUtils.reduceCoordinates(baseObject);
+            ObjectUtils.zoomAll(camera, object, aspect);
+
+            application.selection.set(object);
+            application.initControllers(object);
+
+            application.notifyObjectsChanged([baseObject, camera], this);
+            application.progressBar.visible = false;
+
+            resolve(object);
+          },
+          onError: error =>
+          {
+            console.error(error);
+            application.progressBar.visible = false;
+            MessageDialog.create("ERROR", error)
+              .setClassName("error")
+              .setI18N(application.i18n)
+              .show();
+            reject(error);
+          },
+          manager: application.loadingManager,
+          units: application.setup.units
+        };
+        IOManager.load(intent);
+      };
+
+      application.progressBar.message = "Loading file...";
+      application.progressBar.progress = undefined;
+      application.progressBar.visible = true;
+
+      const formatInfo = IOManager.getFormatInfo(file.name);
+      if (formatInfo?.dataType === "arraybuffer")
+      {
+        reader.readAsArrayBuffer(file);
+      }
+      else
+      {
+        reader.readAsText(file);
+      }
+    });
+  }
+
+  destroy()
+  {
+    this.removeEventListeners();
+    this.hideDropOverlay();
+    this.fileQueue = [];
+  }
+}
+
+export { DragDropHandler };


### PR DESCRIPTION
Modified files:
- css/tools.css: Styles for the drag & drop overlay with inside/outside states
- js/i18n/base.js, base_ca.js, base_es.js: Drag & drop translations
- js/ui/Application.js: DragDropHandler initialization

New files:
- js/ui/DragDropHandler.js: File drag & drop handler

Features:
- Visual overlay that changes depending on whether you’re in a valid drop area (green +) or not (red ✕)
- Excludes panels such as FileExplorer from the drop area
- Sequential loading of multiple files via a queue
- File extension validation