### PR TITLE
Add drag-and-drop support for loading multiple files in OpenLocalTool

### DIFF
--- a/bimrocket-webapp/src/main/webapp/css/dialog.css
+++ b/bimrocket-webapp/src/main/webapp/css/dialog.css
@@ -90,6 +90,7 @@ div.dialog > .header > button.minimize
   flex-grow: 1;
   overflow:auto;
   padding: 6px;
+  white-space: pre-wrap;
 }
 
 .dialog > .footer

--- a/bimrocket-webapp/src/main/webapp/css/tools.css
+++ b/bimrocket-webapp/src/main/webapp/css/tools.css
@@ -1477,3 +1477,48 @@ div.script_code
   to { width: 24px; }
 }
 
+.drop-indicator,
+.no-drop-indicator
+{
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.drop-indicator .drop-text
+{
+  font-family: Montserrat, Arial;
+  font-size: 14px;
+  color: #404040;
+  background-color: #f0f0f0;
+  padding: 8px 16px;
+  border-radius: 3px;
+  border: 1px solid #ff8080;
+  box-shadow: 0px 0px 3px 0px rgba(50, 50, 50, 0.2);
+}
+
+.no-drop-indicator .no-drop-text
+{
+  font-family: Montserrat, Arial;
+  font-size: 13px;
+  color: #606060;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 6px 12px;
+  border-radius: 2px;
+  border: 1px solid #c0c0c0;
+  box-shadow: 0px 0px 3px 0px rgba(50, 50, 50, 0.2);
+}
+
+@media all and (max-width : 768px)
+{
+  .drop-indicator,
+  .no-drop-indicator
+  {
+    top: 20%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base.js
@@ -119,6 +119,8 @@ export const translations =
 
   "tool.openlocal.label" : "Open from local disk",
   "tool.openlocal.help" : "Open from local disk",
+  "tool.openlocal.drop_here" : "Drop files here",
+  "tool.openlocal.no_drop" : "✕ Drop on canvas only",
 
   "tool.savelocal.label" : "Save to local disk",
   "tool.savelocal.help" : "Save to local disk",
@@ -653,6 +655,8 @@ export const translations =
   "message.link_created" : "Link created.",
 
   "message.solar_simulator_select_faces" : "Select the surface for which you want to calculate solar exposure using the face selection tool.",
+
+  "message.file_open_error" : (fileName, error) => `The file ${fileName} cannot be opened:\n\n${error}`,
 
   "message.edit_acl_success": "Permissions were updated successfully.",
   "message.invalid_privileges": "Errors found in the input privileges.",

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_ca.js
@@ -119,6 +119,8 @@ export const translations =
 
   "tool.openlocal.label" : "Obre del disc local",
   "tool.openlocal.help" : "Obre del disc local",
+  "tool.openlocal.drop_here" : "Deixa els fitxers aquí",
+  "tool.openlocal.no_drop" : "✕ Deixa-ho només al canvas",
 
   "tool.savelocal.label" : "Desa en disc local",
   "tool.savelocal.help" : "Desa en disc local",
@@ -653,6 +655,8 @@ export const translations =
   "message.link_created" : "Enllaç creat.",
 
   "message.solar_simulator_select_faces" : "Selecciona la superfície sobre la qual vols calcular l'exposició solar mitjançant l'eina de selecció de cares.",
+
+  "message.file_open_error" : (fileName, error) => `El fitxer ${fileName} no es pot obrir:\n\n${error}`,
 
   "message.edit_acl_success": "Els permisos s'han actualitzat correctament.",
   "message.invalid_privileges": "Hi ha errors en els privilegis introduïts.",

--- a/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
+++ b/bimrocket-webapp/src/main/webapp/js/i18n/base_es.js
@@ -119,6 +119,8 @@ export const translations =
 
   "tool.openlocal.label" : "Abrir del disco local",
   "tool.openlocal.help" : "Abrir del disco local",
+  "tool.openlocal.drop_here" : "Suelta los archivos aquí",
+  "tool.openlocal.no_drop" : "✕ Suelta solo en el canvas",
 
   "tool.savelocal.label" : "Guardar en local",
   "tool.savelocal.help" : "Guardar en local",
@@ -653,6 +655,8 @@ export const translations =
   "message.link_created" : "Enlace creado.",
 
   "message.solar_simulator_select_faces" : "Selecciona la superficie sobre la que quieres calcular la exposición solar mediante la herramienta de selección de caras.",
+
+  "message.file_open_error" : (fileName, error) => `El fichero ${fileName} no se puede abrir:\n\n${error}`,
 
   "message.edit_acl_success" : "Los permisos se han actualizado correctamente.",
   "message.invalid_privileges": "Hay errores en los privilegios introducidos.",

--- a/bimrocket-webapp/src/main/webapp/js/tools/OpenLocalTool.js
+++ b/bimrocket-webapp/src/main/webapp/js/tools/OpenLocalTool.js
@@ -8,6 +8,7 @@ import { Tool } from "./Tool.js";
 import { IOManager } from "../io/IOManager.js";
 import { ObjectUtils } from "../utils/ObjectUtils.js";
 import { MessageDialog } from "../ui/MessageDialog.js";
+import { I18N } from "../i18n/I18N.js";
 
 class OpenLocalTool extends Tool
 {
@@ -23,6 +24,88 @@ class OpenLocalTool extends Tool
 
     this._onChange = this.onChange.bind(this);
     this._onFocus = this.onFocus.bind(this);
+
+    this.fileQueue = [];
+    this.isProcessing = false;
+
+    this.createDropIndicator();
+    this.registerDragAndDrop();
+  }
+
+  createDropIndicator()
+  {
+    const container = this.application.container;
+
+    const dropIndicator = document.createElement("div");
+    dropIndicator.className = "drop-indicator";
+
+    const text = document.createElement("div");
+    text.className = "drop-text";
+    I18N.set(text, "textContent", "tool.openlocal.drop_here");
+    dropIndicator.appendChild(text);
+
+    container.appendChild(dropIndicator);
+    this.dropIndicator = dropIndicator;
+
+    const noDropIndicator = document.createElement("div");
+    noDropIndicator.className = "no-drop-indicator";
+
+    const noDropText = document.createElement("div");
+    noDropText.className = "no-drop-text";
+    I18N.set(noDropText, "textContent", "tool.openlocal.no_drop");
+    noDropIndicator.appendChild(noDropText);
+
+    container.appendChild(noDropIndicator);
+    this.noDropIndicator = noDropIndicator;
+
+    this.application.i18n.update(dropIndicator);
+    this.application.i18n.update(noDropIndicator);
+  }
+
+  showDropIndicator()
+  {
+    if (this.dropIndicator)
+    {
+      this.dropIndicator.style.display = "block";
+    }
+    if (this.noDropIndicator)
+    {
+      this.noDropIndicator.style.display = "none";
+    }
+    const canvas = this.application.container.querySelector('canvas');
+    if (canvas)
+    {
+      canvas.style.opacity = "0.85";
+    }
+  }
+
+  hideDropIndicator()
+  {
+    if (this.dropIndicator)
+    {
+      this.dropIndicator.style.display = "none";
+    }
+    if (this.noDropIndicator)
+    {
+      this.noDropIndicator.style.display = "none";
+    }
+    const canvas = this.application.container.querySelector('canvas');
+    if (canvas)
+    {
+      canvas.style.opacity = "";
+    }
+  }
+
+  showNoDropIndicator()
+  {
+    if (this.dropIndicator)
+    {
+      this.dropIndicator.style.display = "none";
+    }
+    if (this.noDropIndicator)
+    {
+      this.noDropIndicator.style.display = "block";
+    }
   }
 
   activate()
@@ -31,6 +114,7 @@ class OpenLocalTool extends Tool
     this.inputFile = inputFile;
 
     inputFile.type = "file";
+    inputFile.multiple = true;
     inputFile.id = this.name + "_file";
 
     const extensions = IOManager.getSupportedLoaderExtensions();
@@ -57,75 +141,241 @@ class OpenLocalTool extends Tool
     let files = this.inputFile.files;
     if (files.length > 0)
     {
-      let file = files[0];
-      let reader = new FileReader();
-      const application = this.application;
-      const t0 = Date.now();
-      reader.onload = evt =>
+      for (let i = 0; i < files.length; i++)
       {
-        const t1 = Date.now();
-        console.info("File read as text in " + (t1 - t0) + " millis.");
+        this.fileQueue.push(files[i]);
+      }
+      this.processQueue();
+    }
+  }
 
-        let data = evt.target.result;
-        let intent =
+  processQueue()
+  {
+    if (this.isProcessing || this.fileQueue.length === 0)
+    {
+      return;
+    }
+
+    this.isProcessing = true;
+    const file = this.fileQueue.shift();
+    this.uploadFile(file);
+  }
+
+  uploadFile(file)
+  {
+    if (!this.isValidFile(file))
+    {
+      const message = this.application.i18n.get("message.file_open_error", file.name, "Unsupported format");
+      MessageDialog.create("ERROR", message)
+        .setClassName("error")
+        .setAction(() =>
         {
-          url : "file://" + file.name,
-          data : data,
-          onProgress : data =>
-          {
-            application.progressBar.progress = data.progress;
-            application.progressBar.message = data.message;
-          },
-          onCompleted : object =>
-          {
-            const container = application.container;
-            const baseObject = application.baseObject;
-            const aspect = container.clientWidth / container.clientHeight;
-            const camera = application.camera;
+          this.isProcessing = false;
+          this.processQueue();
+        })
+        .setI18N(this.application.i18n).show();
+      return;
+    }
 
-            object.updateMatrix();
-            application.addObject(object, baseObject);
+    let reader = new FileReader();
+    const application = this.application;
+    const t0 = Date.now();
+    reader.onload = evt =>
+    {
+      const t1 = Date.now();
+      console.info("File read as text in " + (t1 - t0) + " millis.");
 
-            ObjectUtils.reduceCoordinates(baseObject);
-            ObjectUtils.zoomAll(camera, object, aspect);
+      let data = evt.target.result;
+      let intent =
+      {
+        url : "file://" + file.name,
+        data : data,
+        onProgress : data =>
+        {
+          application.progressBar.progress = data.progress;
+          application.progressBar.message = data.message;
+        },
+        onCompleted : object =>
+        {
+          const container = application.container;
+          const baseObject = application.baseObject;
+          const aspect = container.clientWidth / container.clientHeight;
+          const camera = application.camera;
 
-            application.selection.set(object);
-            application.initControllers(object);
+          object.updateMatrix();
+          application.addObject(object, baseObject);
 
-            application.notifyObjectsChanged([baseObject, camera], this);
-            application.progressBar.visible = false;
-          },
-          onError : error =>
-          {
-            console.error(error);
-            application.progressBar.visible = false;
-            MessageDialog.create("ERROR", error)
-              .setClassName("error")
-              .setI18N(application.i18n).show();
-          },
-          manager : this.application.loadingManager,
-          units : application.setup.units
-        };
-        IOManager.load(intent); // async load
+          ObjectUtils.reduceCoordinates(baseObject);
+          ObjectUtils.zoomAll(camera, object, aspect);
+
+          application.selection.set(object);
+          application.initControllers(object);
+
+          application.notifyObjectsChanged([baseObject, camera], this);
+          application.progressBar.visible = false;
+
+          this.isProcessing = false;
+          this.processQueue();
+        },
+        onError : error =>
+        {
+          console.error(error);
+
+          const errorMessage = String(error);
+          const message = application.i18n.get("message.file_open_error", file.name, errorMessage);
+          MessageDialog.create("ERROR", message)
+            .setClassName("error")
+            .setAction(() =>
+            {
+              this.isProcessing = false;
+              this.processQueue();
+            })
+            .setI18N(this.application.i18n).show();
+        },
+        manager : this.application.loadingManager,
+        units : application.setup.units
       };
-      application.progressBar.message = "Loading file...";
-      application.progressBar.progress = undefined;
-      application.progressBar.visible = true;
-      let formatInfo = IOManager.getFormatInfo(file.name);
-      if (formatInfo?.dataType === "arraybuffer")
-      {
-        reader.readAsArrayBuffer(file);
-      }
-      else
-      {
-        reader.readAsText(file);
-      }
+      IOManager.load(intent);
+    };
+    application.progressBar.message = "Loading file...";
+    application.progressBar.progress = undefined;
+    application.progressBar.visible = true;
+    let formatInfo = IOManager.getFormatInfo(file.name);
+    if (formatInfo?.dataType === "arraybuffer")
+    {
+      reader.readAsArrayBuffer(file);
+    }
+    else
+    {
+      reader.readAsText(file);
     }
   }
 
   onFocus(event)
   {
     this.application.useTool(null);
+  }
+
+  isValidFile(file)
+  {
+    const supportedExtensions = IOManager.getSupportedLoaderExtensions();
+    const fileName = file.name.toLowerCase();
+    const hasValidExtension = supportedExtensions.some(ext =>
+      fileName.endsWith("." + ext.toLowerCase())
+    );
+
+    if (!hasValidExtension)
+    {
+      console.warn("File type not supported: " + file.name);
+    }
+
+    return hasValidExtension;
+  }
+
+  registerDragAndDrop()
+  {
+    const container = this.application.container;
+    const application = this.application;
+
+    let isOverCanvas = false;
+
+    container.addEventListener('dragenter', e =>
+    {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (application.isCanvasEvent(e))
+      {
+        isOverCanvas = true;
+        container.style.backgroundColor = "rgba(255, 128, 128, 0.08)";
+        container.style.border = "2px dashed #ff8080";
+        container.style.boxShadow = "inset 0 0 10px rgba(255, 128, 128, 0.15)";
+        container.style.cursor = "copy";
+        this.showDropIndicator();
+        e.dataTransfer.dropEffect = 'copy';
+      }
+      else
+      {
+        isOverCanvas = false;
+        container.style.cursor = "not-allowed";
+        this.showNoDropIndicator();
+        e.dataTransfer.dropEffect = 'none';
+      }
+    }, false);
+
+    container.addEventListener('dragover', e =>
+    {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (application.isCanvasEvent(e))
+      {
+        if (!isOverCanvas)
+        {
+          isOverCanvas = true;
+          container.style.cursor = "copy";
+          this.showDropIndicator();
+        }
+        e.dataTransfer.dropEffect = 'copy';
+      }
+      else
+      {
+        if (isOverCanvas)
+        {
+          isOverCanvas = false;
+          container.style.cursor = "not-allowed";
+          this.showNoDropIndicator();
+        }
+        e.dataTransfer.dropEffect = 'none';
+      }
+    }, false);
+
+    container.addEventListener('drop', e =>
+    {
+      e.preventDefault();
+      e.stopPropagation();
+
+      isOverCanvas = false;
+      this.clearContainerStyles();
+      this.hideDropIndicator();
+
+      if (application.isCanvasEvent(e))
+      {
+        const files = e.dataTransfer.files;
+        if (files.length > 0)
+        {
+          Array.from(files).forEach(file => this.fileQueue.push(file));
+          this.processQueue();
+        }
+      }
+    }, false);
+
+    this._boundDragEndHandler = this._boundDragEndHandler || (() =>
+    {
+      isOverCanvas = false;
+      this.clearContainerStyles();
+      this.hideDropIndicator();
+    });
+    window.addEventListener('dragend', this._boundDragEndHandler, false);
+
+    container.addEventListener('dragleave', e =>
+    {
+      if (!e.relatedTarget || !container.contains(e.relatedTarget))
+      {
+        isOverCanvas = false;
+        this.clearContainerStyles();
+        this.hideDropIndicator();
+      }
+    }, false);
+  }
+
+  clearContainerStyles()
+  {
+    const container = this.application.container;
+    container.style.backgroundColor = "";
+    container.style.border = "";
+    container.style.boxShadow = "";
+    container.style.cursor = "";
   }
 }
 


### PR DESCRIPTION
Allow dragging IFC files over the canvas to load models

Show visual feedback: dashed border, subtle tint, and drop indicator

Prevent drops on panels (show 'no-drop' warning instead)

Support multiple files with sequential queue processing

Add translations for drop indicators in English, Catalan, and Spanish

Indicators automatically hide when drag ends or leaves window

Styles defined in tools.css for better maintainability