### PR TITLE
Change in directory creation functionality: The ACL is not created

### DIFF
--- a/bimrocket-server/src/main/java/org/bimrocket/service/file/FileService.java
+++ b/bimrocket-server/src/main/java/org/bimrocket/service/file/FileService.java
@@ -42,12 +42,14 @@ import java.util.logging.Logger;
 import org.bimrocket.api.security.User;
 import org.bimrocket.exception.AccessDeniedException;
 import org.bimrocket.exception.NotAuthorizedException;
+import static org.bimrocket.service.file.Privilege.READ;
+import static org.bimrocket.service.file.Privilege.READ_ACL;
+import static org.bimrocket.service.file.Privilege.WRITE;
+import static org.bimrocket.service.file.Privilege.WRITE_ACL;
 import org.bimrocket.service.file.exception.LockedFileException;
 import org.bimrocket.service.file.store.FileStore;
 import org.bimrocket.service.file.store.filesystem.FileSystemFileStore;
 import org.bimrocket.service.file.util.MutableACL;
-
-import static org.bimrocket.service.file.Privilege.*;
 import static org.bimrocket.service.security.SecurityConstants.ADMIN_ROLE;
 import static org.bimrocket.service.security.SecurityConstants.AUTHENTICATED_ROLE;
 import org.bimrocket.service.security.SecurityService;
@@ -156,11 +158,11 @@ public class FileService
 
     Metadata metadata = store.makeCollection(path);
 
+    /* ACLs are no longer created automatically when creating a new directory.
     MutableACL acl = new MutableACL();
-
     acl.grant(securityService.getCurrentUser().getId(), List.of(READ, WRITE, READ_ACL, WRITE_ACL));
-
     store.setACL(path, acl);
+    */
 
     return metadata;
   }


### PR DESCRIPTION
Following up on what was discussed in previous meetings, we have reviewed the removal of the ACL creation process and it does not pose any problems with the role mechanism.

---------

Co-authored-by: jordi_hernandez <jordi.hernandez@i2cat.net>